### PR TITLE
Adding

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -21,7 +21,6 @@ Describe briefly what security risks you considered, why they don't apply, or ho
 - [ ] [MyDataHelps website](mydatahelps.org)
 
 ### Documentation
-- [ ] I have added relevant Storybook updates to this PR as well.
 - [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.
 
 Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+info@careevolution.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+[![License](https://img.shields.io/github/license/CareEvolution/MyDataHelpsStarterKit)](https://github.com/CareEvolution/MyDataHelpsStarterKit)
+
+## How to contribute to MyDataHelpsUI
+
+#### **Do you want to use MyDataHelpsUI as a starting point for your project?**
+* Fork or clone this repo locally and start to tailor the visualization to support the use case that your study requires. 
+* Learn about Views and [how to integrate your custom views into a MyDataHelps project](https://developer.mydatahelps.org/views/)
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/CareEvolution/MyDataHelpsStarterKit/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/CareEvolution/MyDataHelpsStarterKit/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **data sample** or **test case** demonstrating the expected behavior that is not occurring.
+
+  ##### **If you write a patch to fix a bug**
+
+  * Open a [new pull request](https://github.com/CareEvolution/MyDataHelpsStarterKit/pulls) with the patch.
+
+  * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### **Do you have questions about the source code?**
+
+* Ask any question about how to use MyDataHelpsStarterKit by making a post on [our community forum](https://support.mydatahelps.org/hc/en-us/community/topics/4405770479123-Help-Q-A-).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 [![License](https://img.shields.io/github/license/CareEvolution/MyDataHelpsStarterKit)](https://github.com/CareEvolution/MyDataHelpsStarterKit)
 
-## How to contribute to MyDataHelpsUI
+## How to contribute to MyDataHelpsStarterKit
 
-#### **Do you want to use MyDataHelpsUI as a starting point for your project?**
+#### **Do you want to use MyDataHelpsStarterKit as a starting point for your project?**
 * Fork or clone this repo locally and start to tailor the visualization to support the use case that your study requires. 
 * Learn about Views and [how to integrate your custom views into a MyDataHelps project](https://developer.mydatahelps.org/views/)
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,32 @@ This repository uses the components from [MyDataHelpsUI](https://github.com/Care
 
 1. Clone/copy/fork the code in this repository to your local machine
 2. ```npm install```
-3. Get a [participant access token](https://developer.mydatahelps.org/sdk/participant_tokens.html) - either using browser dev tools while logged in as a test participant, or by using the REST API.
+3. Get a [participant access token](https://developer.mydatahelps.org/sdk/participant_tokens.html) - either using browser dev tools while logged in as a test participant at mydatahelps.org, or by using the REST API.
+    - Hint: if using browser dev tools, examine the response on the request to https://mydatahelps.org/identityserver/connect/token.
 4. Create a .env file with a single line:
 ```
 REACT_APP_PARTICIPANT_ACCESS_TOKEN={your access token}
 ```
 5. ```npm start```
 
-You should see the default project home page appear and populate itself with data from your participant.
+You should see the default project home page appear and populate itself with data from your participant
 
-Navigate to other routes defined in ```src/index.js``` to see more pre-built views, or build your own!
+Navigate to other routes defined in ```src/index.js``` to see more pre-built views, edit existing views, or build your own!
+
+**Important:** *These views are static, based on your participant's data at the time the page is loaded. To interact with your view, follow the instructions in [Hosting your project](#hosting-your-project) to embed your view within MyDataHelps.* 
 
 ## Exploring the Code
 
-A handful of views are set up already that you can see referenced in MyDataHelps.js.
+A handful of views have been set up already to walk you through various use cases that you may encounter when building your custom view.
 
-- Some views, such as "ConnectEhr", just include the pre-built views in MyDataHelpsUI.  
-- "Home" and "DeviceData" views showcase how you can use or reorder the various MyDataHelpsUI components
-- "TaskProgress" is a custom view with a custom component (inside src/components/TaskProgress) showing how you can write your own components
+#### I want to use a pre-built view from MyDataHelpsUI:
+"ConnectEhr" 
+
+#### I want to reorder the various MyDataHelpsUI components to make my own view:
+- "Home" and "DeviceData" views 
+
+#### I want to build my own custom components and views
+- "TaskProgress" is a custom view with a custom component (inside src/components/TaskProgress)
 
 ## Hosting your project
 

--- a/README.md
+++ b/README.md
@@ -20,25 +20,28 @@ You should see the default project home page appear and populate itself with dat
 
 Navigate to other routes defined in ```src/index.js``` to see more pre-built views, edit existing views, or build your own!
 
-**Important:** *These views are static, based on your participant's data at the time the page is loaded. To interact with your view, follow the instructions in [Hosting your project](#hosting-your-project) to embed your view within MyDataHelps.* 
+**Important:** *Views examined locally are static and reflect your participant's data at the time the page is loaded. To interact with your view, follow the instructions in [Hosting your project](#hosting-your-project) to embed your view within MyDataHelps.* 
 
 ## Exploring the Code
 
 A handful of views have been set up already to walk you through various use cases that you may encounter when building your custom view.
 
-#### I want to use a pre-built view from MyDataHelpsUI:
-"ConnectEhr" 
+#### I want to use a pre-built view from MyDataHelpsUI.
+The "ConnectEhr" view just includes pre-built views from MyDataHelpsUI
 
 #### I want to reorder the various MyDataHelpsUI components to make my own view:
-- "Home" and "DeviceData" views 
+- "Home" and "DeviceData" views show you how to import specific components into your view
 
 #### I want to build my own custom components and views
 - "TaskProgress" is a custom view with a custom component (inside src/components/TaskProgress)
 
+#### I want to edit one of the MyDataHelpsUI components:
+To edit a component, you may wish to build a new custom component that models the logic used to build the [original component in MyDataHelpsUI](https://github.com/CareEvolution/MyDataHelpsUI/tree/main/src/components)
+
 ## Hosting your project
 
-To be embedded inside MyDataHelps, your custom view must be hosted on the internet.  
+To test these views or use for study participants, the views must be embedded inside MyDataHelps. To do so, your custom view must be hosted on the internet.  
 
 [View the Guide on Hosting Views](https://developer.mydatahelps.org/views/hosting.html)
 
-Once you have hosted your view, use the "App Layout" tab in your project to point to the url(s) for your view(s).
+Once you have hosted your view, [configure your view as a project tab](https://developer.mydatahelps.org/views/#configuring-views-as-project-tabs) by using the "App Layout" tab in your project settings to point to the url(s) for your view(s).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mydatahelpsviewlibrary",
+  "name": "mydatahelps-starterkit",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "mydatahelpsviewlibrary",
+      "name": "mydatahelps-starterkit",
       "version": "1.0.0",
       "dependencies": {
         "@careevolution/mydatahelps-js": "^3.2.0",


### PR DESCRIPTION
## Overview

Updating documentation to:
1. Add help for finding ppt access token. 
2. Adding link to MyDataHelpsUI
3. Adding information about why to embed within MyDataHelps.
4. Restructuring the examples of what is in the repo. 

Wondering if we should get rid of the "if you want to edit a component, because it's not helpful, but i think it might be an actual use case. 

Adding other logistics stuff like Code of Conduct and Contributing

## Security

REMINDER: All file contents are public.

- [X ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

only adding links to other public sites. 

## Checklist

### Testing
Tested in markdown previewer.

### Documentation
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner